### PR TITLE
SimpleSigner: change network to interface

### DIFF
--- a/core/networks.go
+++ b/core/networks.go
@@ -154,16 +154,16 @@ func (n Network) SlotsPerEpoch() uint64 {
 
 // EstimatedCurrentSlot returns the estimation of the current slot
 func (n Network) EstimatedCurrentSlot() phase0.Slot {
-	return n.EstimatedSlotAtTime(time.Now().Unix())
+	return n.EstimatedSlotAtTime(time.Now())
 }
 
 // EstimatedSlotAtTime estimates slot at the given time
-func (n Network) EstimatedSlotAtTime(time int64) phase0.Slot {
+func (n Network) EstimatedSlotAtTime(time time.Time) phase0.Slot {
 	genesis := int64(n.MinGenesisTime())
-	if time < genesis {
+	if time.Unix() < genesis {
 		return 0
 	}
-	return phase0.Slot(uint64(time-genesis) / uint64(n.SlotDurationSec().Seconds()))
+	return phase0.Slot(uint64(time.Unix()-genesis) / uint64(n.SlotDurationSec().Seconds()))
 }
 
 // EstimatedCurrentEpoch estimates the current epoch

--- a/core/networks_test.go
+++ b/core/networks_test.go
@@ -16,6 +16,6 @@ func TestNetworkMainnet(t *testing.T) {
 	secondsPassedSinceGenesis := time.Now().Unix() - 1606824023
 	require.EqualValues(t, phase0.Epoch(secondsPassedSinceGenesis/(12*32)), net.EstimatedCurrentEpoch())
 	require.EqualValues(t, phase0.Epoch(secondsPassedSinceGenesis/12), net.EstimatedCurrentSlot())
-	require.EqualValues(t, phase0.Epoch(secondsPassedSinceGenesis/12), net.EstimatedSlotAtTime(time.Now().Unix()))
+	require.EqualValues(t, phase0.Epoch(secondsPassedSinceGenesis/12), net.EstimatedSlotAtTime(time.Now()))
 	require.EqualValues(t, phase0.Epoch(101010/32), net.EstimatedEpochAtSlot(phase0.Slot(101010)))
 }

--- a/signer/far_future_protection.go
+++ b/signer/far_future_protection.go
@@ -4,22 +4,18 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-
-	"github.com/ssvlabs/eth2-key-manager/core"
 )
 
-// FarFutureMaxValidEpoch is the max epoch of far future signing
-var FarFutureMaxValidEpoch = int64(time.Minute.Seconds() * 20)
+// MaxFarFutureDelta is the max delta of far future signing
+var MaxFarFutureDelta = time.Minute * 20
 
-// IsValidFarFutureEpoch prevents far into the future signing request, verify a slot is within the current epoch
-// https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/validator.md#protection-best-practices
-func IsValidFarFutureEpoch(network core.Network, epoch phase0.Epoch) bool {
-	maxValidEpoch := network.EstimatedEpochAtSlot(network.EstimatedSlotAtTime(time.Now().Unix() + FarFutureMaxValidEpoch))
+func IsValidFarFutureEpoch(network Network, epoch phase0.Epoch) bool {
+	maxValidEpoch := network.EstimatedEpochAtSlot(network.EstimatedSlotAtTime(time.Now().Add(MaxFarFutureDelta)))
 	return epoch <= maxValidEpoch
 }
 
 // IsValidFarFutureSlot returns true if the given slot is valid
-func IsValidFarFutureSlot(network core.Network, slot phase0.Slot) bool {
-	maxValidSlot := network.EstimatedSlotAtTime(time.Now().Unix() + FarFutureMaxValidEpoch)
+func IsValidFarFutureSlot(network Network, slot phase0.Slot) bool {
+	maxValidSlot := network.EstimatedSlotAtTime(time.Now().Add(MaxFarFutureDelta))
 	return slot <= maxValidSlot
 }

--- a/signer/sign_attestation_test.go
+++ b/signer/sign_attestation_test.go
@@ -95,7 +95,7 @@ func TestLockSameValidatorInParallel(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, wallet.AddValidatorAccount(acc))
 
-	//// setup signer
+	// // setup signer
 	signer := NewSimpleSigner(wallet, &prot.NoProtection{}, core.MainNetwork)
 
 	attestationDataByts := _byteArray("000000000000000000000000000000003a43a4bf26fb5947e809c1f24f7dc6857c8ac007e535d48e6e4eca2122fd776b0000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000003a43a4bf26fb5947e809c1f24f7dc6857c8ac007e535d48e6e4eca2122fd776b")
@@ -192,7 +192,6 @@ func TestManyValidatorsParallel(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// setup signer
 	signer := NewSimpleSigner(wallet, protector, core.PraterNetwork)
 
 	// Sign attestation in parallel.
@@ -682,7 +681,7 @@ func TestAttestationSignatures(t *testing.T) {
 func TestFarFutureAttestationSignature(t *testing.T) {
 	seed := _byteArray("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fff")
 	network := core.PraterNetwork
-	maxValidEpoch := network.EstimatedEpochAtSlot(network.EstimatedSlotAtTime(time.Now().Unix() + FarFutureMaxValidEpoch))
+	maxValidEpoch := network.EstimatedEpochAtSlot(network.EstimatedSlotAtTime(time.Now().Add(MaxFarFutureDelta)))
 
 	t.Run("max valid source", func(tt *testing.T) {
 		signer, err := setupWithSlashingProtection(t, seed, true, true)

--- a/signer/sign_beacon_block_test.go
+++ b/signer/sign_beacon_block_test.go
@@ -492,7 +492,7 @@ func TestProposalSlashingSignatures(t *testing.T) {
 func TestFarFutureProposalSignature(t *testing.T) {
 	seed := _byteArray("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fff")
 	network := core.PraterNetwork
-	maxValidSlot := network.EstimatedSlotAtTime(time.Now().Unix() + FarFutureMaxValidEpoch)
+	maxValidSlot := network.EstimatedSlotAtTime(time.Now().Add(MaxFarFutureDelta))
 
 	t.Run("max valid source", func(tt *testing.T) {
 		signer, err := setupWithSlashingProtection(t, seed, true, true)

--- a/signer/validator_signer.go
+++ b/signer/validator_signer.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"sync"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
@@ -30,17 +31,22 @@ type ValidatorSigner interface {
 	SignBLSToExecutionChange(blsToExecutionChange *capella.BLSToExecutionChange, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 }
 
+type Network interface {
+	EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch
+	EstimatedSlotAtTime(time time.Time) phase0.Slot
+}
+
 // SimpleSigner implements ValidatorSigner interface
 type SimpleSigner struct {
 	wallet            core.Wallet
 	slashingProtector core.SlashingProtector
-	network           core.Network
+	network           Network
 	signLocks         map[string]*sync.RWMutex
 	mapLock           *sync.RWMutex
 }
 
 // NewSimpleSigner is the constructor of SimpleSigner
-func NewSimpleSigner(wallet core.Wallet, slashingProtector core.SlashingProtector, network core.Network) *SimpleSigner {
+func NewSimpleSigner(wallet core.Wallet, slashingProtector core.SlashingProtector, network Network) *SimpleSigner {
 	return &SimpleSigner{
 		wallet:            wallet,
 		slashingProtector: slashingProtector,


### PR DESCRIPTION
Changes:
- `SimpleSigner` expects an interface type for the `network` parameter instead of `core.Network`

https://github.com/bloxapp/ssv/pull/1308 introduces support of custom network configs where any value can be overridden. Currently, `SimpleSigner` expects the `network` parameter of the type `core.Network` which means that it supports only values stored in this repository. On any other values, it returns default zero-values or crashes. 

Therefore, when the SSV node calls `NewSimpleSigner` on setting up a `KeyManager`, if the network name differs from supported, then `SimpleSigner` would not work as expected.

The `SimpleSigner` uses two `core.Network`'s methods:
- `EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch`
- `EstimatedSlotAtTime(time int64) phase0.Slot`

`EstimatedEpochAtSlot` calls only `SlotsPerEpoch` which returns 32 for any network. However, `EstimatedSlotAtTime` calls `MinGenesisTime` which returns 0 for unknown ones.

The PR changes the type of the `network` parameter to the interface below to allow the SSV node to just pass any network matching the interface.
```go
type network interface {
	EstimatedEpochAtSlot(slot phase0.Slot) phase0.Epoch
	EstimatedSlotAtTime(time int64) phase0.Slot
}
```