### PR TITLE
hotfix: allow signing *electra.AggregateAndProof

### DIFF
--- a/signer/sign_aggregate_and_proof.go
+++ b/signer/sign_aggregate_and_proof.go
@@ -4,11 +4,14 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 )
 
-// SignAggregateAndProof signs aggregate and proof
-func (signer *SimpleSigner) SignAggregateAndProof(agg *phase0.AggregateAndProof, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
+// SignAggregateAndProof signs aggregate and proof.
+// It can be *phase0.AggregateAndProof or *electra.AggregateAndProof since electra.
+// As we don't use any AggregateAndProof's fields, we can just use ssz.HashRoot.
+func (signer *SimpleSigner) SignAggregateAndProof(agg ssz.HashRoot, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
 	// 1. check we can even sign this
 	// TODO - should we?
 

--- a/signer/validator_signer.go
+++ b/signer/validator_signer.go
@@ -19,7 +19,7 @@ type ValidatorSigner interface {
 	SignBeaconBlock(block *spec.VersionedBeaconBlock, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignBlindedBeaconBlock(block *api.VersionedBlindedBeaconBlock, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignBeaconAttestation(attestation *phase0.AttestationData, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
-	SignAggregateAndProof(agg *phase0.AggregateAndProof, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
+	SignAggregateAndProof(agg ssz.HashRoot, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignSlot(slot phase0.Slot, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignEpoch(epoch phase0.Epoch, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignSyncCommittee(msgBlockRoot []byte, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)


### PR DESCRIPTION
Since electra fork, `AggregateAndProof` can be of two types: `*phase0.AggregateAndProof` and `*electra.AggregateAndProof`. https://github.com/ssvlabs/eth2-key-manager/pull/111 doesn't add an ability to sign `*electra.AggregateAndProof`, so the ssv-nodes cannot sign aggregate and proof and have `could not sign beacon object: could not cast obj to AggregateAndProof` in their logs