### PR TITLE
preconfs: preconf-commitment duty

### DIFF
--- a/signer/sign_preconf_commitment.go
+++ b/signer/sign_preconf_commitment.go
@@ -1,0 +1,34 @@
+package signer
+
+import (
+	"encoding/hex"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+)
+
+// TODO - add test(s)
+// SignSlot signes the given preconf-commitment data
+func (signer *SimpleSigner) SignPreconfCommitment(data []byte, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
+	if pubKey == nil {
+		return nil, nil, errors.New("account was not supplied")
+	}
+
+	account, err := signer.wallet.AccountByPublicKey(hex.EncodeToString(pubKey))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sszRoot := SSZBytes(data)
+	root, err := ComputeETHSigningRoot(sszRoot, domain)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sig, err := account.ValidationKeySign(root[:])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return sig, root[:], nil
+}

--- a/signer/validator_signer.go
+++ b/signer/validator_signer.go
@@ -28,6 +28,7 @@ type ValidatorSigner interface {
 	SignRegistration(registration *api.VersionedValidatorRegistration, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignVoluntaryExit(voluntaryExit *phase0.VoluntaryExit, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignBLSToExecutionChange(blsToExecutionChange *capella.BLSToExecutionChange, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
+	SignPreconfCommitment(data []byte, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 }
 
 // SimpleSigner implements ValidatorSigner interface


### PR DESCRIPTION
This PR defines the necessary primitives we need for preconf-commitment duty (Ethereum pre-confirmations) - corresponding PR in ssv repo is https://github.com/ssvlabs/ssv/pull/2063