### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: 1.21
 

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: 1.21
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup make
         run: sudo apt-get update && sudo apt-get install make

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install make
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: 1.21
 


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.