### PR TITLE
signer: accept a narrow HashRoot interface (dynamic-ssz compat)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ UNFORMATTED=$(shell gofmt -s -l .)
 .PHONY: lint-prepare
 lint-prepare:
 	@echo "Preparing Linter"
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s latest
+	# Pin the installer to a release tag (not master) and pin the version, for
+	# reproducible, checksum-verified installs. The master install.sh currently
+	# fails checksum verification for every version.
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b ./bin v2.12.2
 
 .PHONY: lint
 lint:

--- a/signer/sign_aggregate_and_proof.go
+++ b/signer/sign_aggregate_and_proof.go
@@ -4,14 +4,13 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 )
 
 // SignAggregateAndProof signs aggregate and proof.
 // It can be *phase0.AggregateAndProof or *electra.AggregateAndProof since electra.
-// As we don't use any AggregateAndProof's fields, we can just use ssz.HashRoot.
-func (signer *SimpleSigner) SignAggregateAndProof(agg ssz.HashRoot, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
+// As we don't use any AggregateAndProof's fields, we can just use HashRoot.
+func (signer *SimpleSigner) SignAggregateAndProof(agg HashRoot, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
 	// 1. check we can even sign this
 	// TODO - should we?
 

--- a/signer/sign_beacon_block.go
+++ b/signer/sign_beacon_block.go
@@ -3,7 +3,6 @@ package signer
 import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 )
 
@@ -14,7 +13,7 @@ func (signer *SimpleSigner) SignBeaconBlock(b *spec.VersionedBeaconBlock, domain
 		return nil, nil, errors.Wrap(err, "could not get block slot")
 	}
 
-	var block ssz.HashRoot
+	var block HashRoot
 	switch b.Version {
 	case spec.DataVersionPhase0:
 		block = b.Phase0

--- a/signer/sign_blinded_beacon_block.go
+++ b/signer/sign_blinded_beacon_block.go
@@ -4,7 +4,6 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 )
 
@@ -15,7 +14,7 @@ func (signer *SimpleSigner) SignBlindedBeaconBlock(b *api.VersionedBlindedBeacon
 		return nil, nil, errors.Wrap(err, "could not get block slot")
 	}
 
-	var block ssz.HashRoot
+	var block HashRoot
 	switch b.Version {
 	case spec.DataVersionBellatrix:
 		block = b.Bellatrix

--- a/signer/sign_block.go
+++ b/signer/sign_block.go
@@ -4,14 +4,13 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 
 	"github.com/ssvlabs/eth2-key-manager/core"
 )
 
 // SignBlock signs the given beacon block
-func (signer *SimpleSigner) SignBlock(block ssz.HashRoot, slot phase0.Slot, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
+func (signer *SimpleSigner) SignBlock(block HashRoot, slot phase0.Slot, domain phase0.Domain, pubKey []byte) ([]byte, []byte, error) {
 	// 1. get the account
 	if pubKey == nil {
 		return nil, nil, errors.New("account was not supplied")

--- a/signer/sign_registration.go
+++ b/signer/sign_registration.go
@@ -6,7 +6,6 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 )
 
@@ -26,7 +25,7 @@ func (signer *SimpleSigner) SignRegistration(registration *api.VersionedValidato
 		return nil, nil, err
 	}
 
-	var reg ssz.HashRoot
+	var reg HashRoot
 	switch registration.Version {
 	case spec.BuilderVersionV1:
 		if registration.V1 == nil {

--- a/signer/validator_signer.go
+++ b/signer/validator_signer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 	"github.com/google/uuid"
 
 	"github.com/ssvlabs/eth2-key-manager/core"
@@ -20,7 +19,7 @@ type ValidatorSigner interface {
 	SignBeaconBlock(block *spec.VersionedBeaconBlock, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignBlindedBeaconBlock(block *api.VersionedBlindedBeaconBlock, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignBeaconAttestation(attestation *phase0.AttestationData, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
-	SignAggregateAndProof(agg ssz.HashRoot, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
+	SignAggregateAndProof(agg HashRoot, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignSlot(slot phase0.Slot, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignEpoch(epoch phase0.Epoch, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
 	SignSyncCommittee(msgBlockRoot []byte, domain phase0.Domain, pubKey []byte) (sig []byte, root []byte, err error)
@@ -70,8 +69,15 @@ func (signer *SimpleSigner) lock(accountID uuid.UUID, operation string) *sync.RW
 	}
 }
 
+// HashRoot is the minimal interface needed to compute a signing root: just
+// HashTreeRoot(). fastssz's ssz.HashRoot additionally requires GetTree(), which
+// dynamic-ssz-generated types (go-eth2-client Gloas) do not implement.
+type HashRoot interface {
+	HashTreeRoot() ([32]byte, error)
+}
+
 // ComputeETHSigningRoot returns computed root for eth signing
-func ComputeETHSigningRoot(obj ssz.HashRoot, domain phase0.Domain) (phase0.Root, error) {
+func ComputeETHSigningRoot(obj HashRoot, domain phase0.Domain) (phase0.Root, error) {
 	root, err := obj.HashTreeRoot()
 	if err != nil {
 		return phase0.Root{}, err

--- a/signer/validator_signer_test.go
+++ b/signer/validator_signer_test.go
@@ -1,0 +1,66 @@
+package signer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+)
+
+// hashRootOnly implements only HashTreeRoot() — the single method the signer's
+// HashRoot interface requires — and deliberately omits fastssz's GetTree(). It
+// pins the narrowed contract: if HashRoot is ever widened back to ssz.HashRoot
+// (or gains another method), the compile-time assertion below fails here rather
+// than silently breaking dynamic-ssz-generated Gloas types downstream.
+type hashRootOnly struct {
+	root [32]byte
+}
+
+func (h hashRootOnly) HashTreeRoot() ([32]byte, error) { return h.root, nil }
+
+// Compile-time guard: a type exposing only HashTreeRoot() must satisfy HashRoot.
+var _ HashRoot = hashRootOnly{}
+
+// hashRootErr satisfies HashRoot but always fails, to exercise the error path.
+type hashRootErr struct{}
+
+func (hashRootErr) HashTreeRoot() ([32]byte, error) {
+	return [32]byte{}, errors.New("hash tree root failed")
+}
+
+// TestComputeETHSigningRoot_NarrowContract verifies that a value implementing
+// only HashRoot (not fastssz's ssz.HashRoot) both satisfies the interface and
+// is signed correctly end-to-end.
+func TestComputeETHSigningRoot_NarrowContract(t *testing.T) {
+	var objRoot [32]byte
+	for i := range objRoot {
+		objRoot[i] = byte(i + 1)
+	}
+	var domain phase0.Domain
+	for i := range domain {
+		domain[i] = byte(0xf0 - i)
+	}
+
+	got, err := ComputeETHSigningRoot(hashRootOnly{root: objRoot}, domain)
+	require.NoError(t, err)
+
+	// The object's HashTreeRoot() output must flow into the signing container,
+	// so recomputing the signing root independently must match.
+	want, err := (&phase0.SigningData{ObjectRoot: objRoot, Domain: domain}).HashTreeRoot()
+	require.NoError(t, err)
+	require.Equal(t, phase0.Root(want), got)
+
+	// A different object root must yield a different signing root, i.e. the
+	// object is actually mixed in rather than ignored.
+	other, err := ComputeETHSigningRoot(hashRootOnly{root: [32]byte{0xbb}}, domain)
+	require.NoError(t, err)
+	require.NotEqual(t, got, other)
+}
+
+// TestComputeETHSigningRoot_PropagatesHashTreeRootError verifies that a failure
+// from the object's HashTreeRoot() is surfaced rather than swallowed.
+func TestComputeETHSigningRoot_PropagatesHashTreeRootError(t *testing.T) {
+	_, err := ComputeETHSigningRoot(hashRootErr{}, phase0.Domain{})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Prepares eth2-key-manager for SSV's ePBS/Gloas migration to `pk910/dynamic-ssz`.

go-eth2-client's Gloas types (`spec/gloas`) are generated by dynamic-ssz, which implements `HashTreeRoot()` but **not** fastssz's `GetTree()`. `ComputeETHSigningRoot` and the `sign_*` helpers only ever call `HashTreeRoot()`, so this narrows their object parameter from fastssz's `ssz.HashRoot` to a local `HashRoot` interface exposing just `HashTreeRoot()`.

Backward-compatible (fastssz types still satisfy it); no go.mod change (still builds against go-eth2-client v0.27.0). Builds + `signer` tests pass.
